### PR TITLE
Add missing implementation

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -45,6 +45,7 @@ dependencies {
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
 
     implementation 'com.android.support:appcompat-v7:28.0.0'
+    implementation 'com.android.support:support-annotations:28.0.0'
 
     implementation ('io.branch.sdk.android:library:3.+') {
         exclude module: 'answers-shim'


### PR DESCRIPTION
I believe you need to include this in the dependencies list because the lib is imported here:

https://github.com/boundstate/capacitor-branch-deep-links/blob/master/android/src/main/java/co/boundstate/BranchDeepLinks.java#L5

I had a conversation in Android United on slack about this here:
https://android-united.slack.com/archives/C0406TZT5/p1572942522027200

Without this, jetifier can't correctly identify the import over in BranchDeepLinks.java and do its magic re-writing for androidx support.

I suppose to verify, you need to migrate your whole project to androidx which might be a bit of a beast.